### PR TITLE
There is no official method to access paging links in these tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,18 @@ If the ID key is supplied in any way, that will take precedence.
 
 Ex: [Adding a candidate to Greenhouse](https://developers.greenhouse.io/harvest.html#post-add-candidate)
 
-**A note on paging**: As mentioned in the Harvest documentation, Greenhouse supports two methods of paging depending on the Endpoint. The next page is always shown in a Link header. This link is accessible via the Harvest service.
+**A note on paging**: As mentioned in the Harvest documentation, Greenhouse supports two methods of paging depending on the endpoint. The next page is returned in a Link header. The next page link is accessible in the Harvest Service at:
 
 ```
-$harvestService->getNextLink();
+  $harvestService->nextLink();
 ```
 
-The link returned by this method will give you the next page of objects on this endpoint. If this link is empty, you have reached the last page.
+The link returned by this method will give you the next page of objects on this endpoint. Depending on which paging method the endpoint supports, the link returned will look like one of the following:
 
+- `https://harvest.greenhouse.io/v1/<object>?page=2&per_page=100`
+- `https://harvest.greenhouse.io/v1/<object>/?since_id=161963`
+
+If the nextLink() method returns nothing, you have reached the last page.
 
 Greenhouse includes several methods in Harvest to POST new objects.  It should be noted that the creation of candidates and applications in Harvest differs from the Application service above.  Documents via Harvest can only be received via binary content or by including a URL which contains the document.  As such, the Harvest service uses the `body` parameter in Guzzle instead of including POST parameters.
 ```

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This prevents issues that arise for systems that do not understand the array-ind
 Use this service to interact with the Harvest API in Greenhouse.  Documentation for the Harvest API [can be found here.](https://developers.greenhouse.io/harvest.html/)  The purpose of this service is to make interactions with the Harvest API easier.  To create a Harvest Service object, you must supply an active Harvest API key.  Note that these are different than Job Board API keys.
 ```
 <?php
-$harvestService = $greenhouseService->getHarvestService();
+  $harvestService = $greenhouseService->getHarvestService();
 ?>
 ```
 
@@ -185,6 +185,15 @@ $harvestService->getApplications($parameters);
 If the ID key is supplied in any way, that will take precedence.
 
 Ex: [Adding a candidate to Greenhouse](https://developers.greenhouse.io/harvest.html#post-add-candidate)
+
+**A note on paging**: As mentioned in the Harvest documentation, Greenhouse supports two methods of paging depending on the Endpoint. The next page is always shown in a Link header. This link is accessible via the Harvest service.
+
+```
+$harvestService->getNextLink();
+```
+
+The link returned by this method will give you the next page of objects on this endpoint. If this link is empty, you have reached the last page.
+
 
 Greenhouse includes several methods in Harvest to POST new objects.  It should be noted that the creation of candidates and applications in Harvest differs from the Application service above.  Documents via Harvest can only be received via binary content or by including a URL which contains the document.  As such, the Harvest service uses the `body` parameter in Guzzle instead of including POST parameters.
 ```

--- a/src/Clients/ApiClientInterface.php
+++ b/src/Clients/ApiClientInterface.php
@@ -47,4 +47,19 @@ interface ApiClientInterface
      * future client.
      */
     public function send($method, $url, Array $options);
+    
+    /**
+     * These methods are to return the paging links as described in the Harvest docs. We return a Link header
+     * with paging information in next/previous/last format. For Harvest's two paging systems, only the 
+     * getNextLink() method is relevant for both.
+     */
+    public function getNextLink();
+    public function getPrevLink();
+    public function getLastLink();
+    
+    /**
+     * Return the raw response from the client. In case users want information that is otherwise unavailable
+     * through this package.
+     */
+    public function getResponse();
 }

--- a/src/Services/HarvestService.php
+++ b/src/Services/HarvestService.php
@@ -43,6 +43,25 @@ class HarvestService extends ApiService
     }
     
     /**
+     * The following 3 methods are for Harvest Paging. They return paging info from the Link header (if it
+     * exists). Paging is complete if 'nextLink' returns nothing.
+     */
+    public function nextLink()
+    {
+        return $this->_apiClient->getNextLink();
+    }
+    
+    public function prevLink()
+    {
+        return $this->_apiClient->getPrevLink();
+    }
+    
+    public function lastLink()
+    {
+        return $this->_apiClient->getLastLink();
+    }
+    
+    /**
      * In order to keep up to date with changes to the Harvest api and not trigger a re-release of this 
      * package each time a new method is created, the magic Call method is used to construct URLs to the
      * Harvest API.  This will use the called method and the arguments provided to create the proper URL

--- a/tests/Clients/Mocks/MockGuzzleResponse.php
+++ b/tests/Clients/Mocks/MockGuzzleResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Greenhouse\GreenhouseToolsPhp\Tests\Clients\Mocks;
+
+/**
+ * This mocks a Guzzle response object. That's all. And currently only the headers in order to test the
+ * link setters in GuzzleClient.
+ */
+class MockGuzzleResponse
+{
+    public $headers;
+    
+    public function getHeader($type)
+    {
+        return $this->headers;
+    }
+}

--- a/tests/Services/HarvestServiceTest.php
+++ b/tests/Services/HarvestServiceTest.php
@@ -3,6 +3,7 @@
 namespace Greenhouse\GreenhouseToolsPhp\Tests\Services;
 
 use Greenhouse\GreenhouseToolsPhp\Services\HarvestService;
+use Greenhouse\GreenhouseToolsPhp\GreenhouseService;
 
 /**
  * This test only tests that the service requests generate the expected links and arrays.  This does not
@@ -15,10 +16,29 @@ class HarvestServiceTest extends \PHPUnit_Framework_TestCase
     {
         $this->harvestService = new HarvestService('greenhouse');
         $apiStub = $this->getMockBuilder('\Greenhouse\GreenhouseToolsPhp\Client\GuzzleClient')
-                        ->setMethods(array('send'))
+                        ->setMethods(array('send', 'getNextLink', 'getPrevLink', 'getLastLink'))
                         ->getMock();
+        $apiStub->method('getNextLink')->willReturn('http://example.com/next');
+        $apiStub->method('getPrevLink')->willReturn('http://example.com/prev');
+        $apiStub->method('getLastLink')->willReturn('http://example.com/last');
+
         $this->harvestService->setClient($apiStub);
         $this->expectedAuth = 'Basic Z3JlZW5ob3VzZTo=';
+    }
+    
+    public function testGetNextLink()
+    {
+        $this->assertEquals($this->harvestService->nextLink(), 'http://example.com/next');
+    }
+    
+    public function testGetPrevLink()
+    {
+        $this->assertEquals($this->harvestService->prevLink(), 'http://example.com/prev');
+    }
+    
+    public function testGetLastLink()
+    {
+        $this->assertEquals($this->harvestService->lastLink(), 'http://example.com/last');
     }
     
     public function testGetActivityFeed()


### PR DESCRIPTION
Harvest returns a Link header for purposes of paging. But currently this package has no method by which to access those tools and keeps the Guzzle response object private. So this package:

- Changes the Client Interface to require methods to access the paging links.
- Sets the paging links if they exists.
- Provides methods in the Harvest Service to access those links.
- Makes the Guzzle response object public if any additional data is required.

Addresses Issue: https://github.com/grnhse/greenhouse-tools-php/issues/14