### PR TITLE
add circle tests for PHP > 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,41 +2,33 @@
 #
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
-version: 2
+version: 2.1
+
 jobs:
-  build:
+  test:
+    parameters:
+      php-version:
+        type: string
     docker:
-      # Specify the version you desire here
-      - image: circleci/php:5.6-node-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
-      #
-      # - image: redis:2.8.19
-
+      - image: circleci/php:<< parameters.php-version >>-node-browsers
     steps:
       - checkout
-
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt update
       - run: sudo docker-php-ext-install zip
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
-            # "composer.lock" can be used if it is committed to the repo
             - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
       - run: composer install -n --prefer-dist
-
       - save_cache:
           key: v1-dependencies-{{ checksum "composer.json" }}
           paths:
             - ./vendor
-
       - run: ./vendor/bin/phpunit
+workflows:
+  all-phps:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              php-version: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]


### PR DESCRIPTION
Instead of just testing PHP 5.6, we want to run the tests over PHP's >= 7.0, too.