### PR TITLE
Fix: postApplication in ApplicationService doesn't work with Guzzle7

### DIFF
--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -66,7 +66,7 @@ class GuzzleClient implements ApiClientInterface
      * @return  string
      * @throws  GreenhouseAPIResponseException  for non-200 responses
      */
-    public function post(Array $postVars, Array $headers, $url=null)
+    public function post(Array $postVars, Array $headers, $url='')
     {
         try {
             $this->guzzleResponse = $this->_client->request(


### PR DESCRIPTION
After upgrading to GuzzleHttp 7, it stopped treating null urls as
empty and instead throws an InvalidArgumentException.

This commit changes $url parameter's default value to an empty
string instead of null.

solves issue #33 