### PR TITLE
Add New Cadidate Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Some method calls and URLs do not fit this format, but the methods were named as
   * `postUnrejectApplication`: [Unreject an application](https://developers.greenhouse.io/harvest.html#post-unreject-application)
   * `postMergeCandidates`: [Merge a duplicate candidate to a primary candidate.](https://developers.greenhouse.io/harvest.html#put-merge-candidates)
   * `getCandidateTags`: [Returns all candidate tags in your organization.](https://developers.greenhouse.io/harvest.html#get-list-candidate-tags)
+  * `postCandidateTags`: [Create a new candidate tag in your organization.](https://developers.greenhouse.io/harvest.html#post-add-new-candidate-tag)
   * `getTagsForCandidate`: [Returns all tags applied to a single candidate.](https://developers.greenhouse.io/harvest.html#get-list-tags-applied-to-candidate)
   * `getCustomFields`: [Returns all custom fields](https://developers.greenhouse.io/harvest.html#get-list-custom-fields): Note for this method, the id argument will contain the type of custom field you want to retrieve.  `$harvestService->getCustomFields(array('id' => 'job'));` will return all the job custom fields in your organization. Leaving this argument blank will return all custom fields.
   * `getTrackingLinks`: [Return a specific traking link for the supplied token.](https://developers.greenhouse.io/harvest.html#get-tracking-link-data-for-token): Note for this link, the token will be provided in the 'id' argument.  `$harvestService->getTrackingLink(array('id' => '<token>'));`

--- a/src/Services/HarvestService.php
+++ b/src/Services/HarvestService.php
@@ -230,6 +230,13 @@ class HarvestService extends ApiService
         return $this->sendRequest();
     }
     
+    public function postCandidateTags($parameters=array())
+    {
+        $this->_harvest = $this->_harvestHelper->parse('postCandidateTags', $parameters);
+        $this->_harvest['url'] = 'tags/candidate';
+        return $this->sendRequest();
+    }
+
     public function patchEnableUser($parameters=array())
     {
         $this->_harvest = $this->_harvestHelper->parse('patchEnableUser', $parameters);

--- a/tests/Services/HarvestServiceTest.php
+++ b/tests/Services/HarvestServiceTest.php
@@ -1301,6 +1301,25 @@ class HarvestServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->expectedAuth, $this->harvestService->getAuthorizationHeader());
     }
     
+    public function testPostCandidateTags()
+    {
+        $expected = array(
+            'method' => 'post',
+            'url' => 'tags/candidate',
+            'headers' => array('On-Behalf-Of' => 234),
+            'body' => '{"name":"Test Tag"}',
+            'parameters' => array()
+        );
+        $params = array(
+            'headers' => array('On-Behalf-Of' => 234),
+            'body' => '{"name":"Test Tag"}',
+        );
+
+        $this->harvestService->postCandidateTags($params);
+        $this->assertEquals($expected, $this->harvestService->getHarvest());
+        $this->assertEquals($this->expectedAuth, $this->harvestService->getAuthorizationHeader());
+    }
+
     public function testGetTagsForCandidate()
     {
         $expected = array(


### PR DESCRIPTION
The API call for [creating a new candidate tag](https://developers.greenhouse.io/harvest.html#post-add-new-candidate-tag) is missing and it
requires a special method handler because the url is singular.

This is exactly the same as #getCandidateTags method, only using
POST instead of GET to send the request.